### PR TITLE
Should be possible to define public access to storage

### DIFF
--- a/dist/rails/storage.json
+++ b/dist/rails/storage.json
@@ -92,6 +92,10 @@
           "type": "string",
           "markdownDescription": "Name of the S3 bucket where files will be stored. Consider including the environment in the name (e.g., `my-bucket-<%= Rails.env %>`) to prevent accidentally destroying production data."
         },
+        "public": {
+          "type": "boolean",
+          "markdownDescription": "Whether files should be publicly accessible. When `true`, generated file URLs are permanent public URLs instead of signed private URLs."
+        },
         "http_open_timeout": {
           "type": ["integer", "string"],
           "markdownDescription": "HTTP open timeout in seconds for S3 client connections. Set sensible timeouts to prevent connections from being held for several minutes in failure scenarios."
@@ -203,6 +207,10 @@
           "type": "string",
           "markdownDescription": "Name of the GCS bucket where files will be stored. Consider including the environment in the name (e.g., `my-bucket-<%= Rails.env %>`)."
         },
+        "public": {
+          "type": "boolean",
+          "markdownDescription": "Whether files should be publicly accessible. When `true`, generated file URLs are permanent public URLs instead of signed private URLs."
+        },
         "cache_control": {
           "type": "string",
           "markdownDescription": "Cache-Control header value for uploaded files. Controls how browsers and CDNs cache the content (e.g., `public, max-age=3600`)."
@@ -237,6 +245,10 @@
         "container": {
           "type": "string",
           "markdownDescription": "Name of the Azure Storage container where files will be stored. Consider including the environment in the name (e.g., `my-container-<%= Rails.env %>`)."
+        },
+        "public": {
+          "type": "boolean",
+          "markdownDescription": "Whether files should be publicly accessible. When `true`, generated file URLs are permanent public URLs instead of signed private URLs."
         }
       },
       "required": [

--- a/test/fixtures/rails/storage/public_gcs.yml
+++ b/test/fixtures/rails/storage/public_gcs.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../dist/rails/storage.json
+%YAML 1.1
+---
+public_gcs:
+  service: GCS
+  project: my-project
+  credentials: <%= Rails.root.join("path/to/public_key.json") %>
+  bucket: my-public-bucket-<%= Rails.env %>
+  public: true


### PR DESCRIPTION
Had a following issues in my project:
<img width="1508" height="383" alt="image" src="https://github.com/user-attachments/assets/e2b77681-9883-45b0-9da9-f0df07402b49" />

But according to rails guides it should be possible to define public storage. See:
https://guides.rubyonrails.org/active_storage_overview.html#public-access

With this change, storage schema now supports the `public:true` attribute. Works the same for S3, GCS and AzureStorage.